### PR TITLE
Move the dont-open-twice logic into the variable-paths component

### DIFF
--- a/ui/app/components/variable-paths.js
+++ b/ui/app/components/variable-paths.js
@@ -26,13 +26,27 @@ export default class VariablePathsComponent extends Component {
   }
 
   @action
-  async handleFolderClick(path) {
+  async handleFolderClick(path, trigger) {
+    // Don't navigate if the user clicked on a link; this will happen with modifier keys like cmd/ctrl on the link itself
+    if (
+      trigger instanceof PointerEvent &&
+      /** @type {HTMLElement} */ (trigger.target).tagName === 'A'
+    ) {
+      return;
+    }
     this.router.transitionTo('variables.path', path);
   }
 
   @action
-  async handleFileClick({ path, variable: { id, namespace } }) {
+  async handleFileClick({ path, variable: { id, namespace } }, trigger) {
     if (this.can.can('read variable', null, { path, namespace })) {
+      // Don't navigate if the user clicked on a link; this will happen with modifier keys like cmd/ctrl on the link itself
+      if (
+        trigger instanceof PointerEvent &&
+        /** @type {HTMLElement} */ (trigger.target).tagName === 'A'
+      ) {
+        return;
+      }
       this.router.transitionTo('variables.variable', id);
     }
   }

--- a/ui/app/controllers/variables/index.js
+++ b/ui/app/controllers/variables/index.js
@@ -6,8 +6,6 @@
 import Controller, { inject as controller } from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
-// eslint-disable-next-line no-unused-vars
-import VariableModel from '../../models/variable';
 
 const ALL_NAMESPACE_WILDCARD = '*';
 
@@ -16,23 +14,6 @@ export default class VariablesIndexController extends Controller {
   @service store;
 
   isForbidden = false;
-
-  /**
-   * Trigger can either be the pointer event itself, or if the keyboard shorcut was used, the html element corresponding to the variable.
-   * @param {VariableModel} variable
-   * @param {PointerEvent|HTMLElement} trigger
-   */
-  @action
-  goToVariable(variable, trigger) {
-    // Don't navigate if the user clicked on a link; this will happen with modifier keys like cmd/ctrl on the link itself
-    if (
-      trigger instanceof PointerEvent &&
-      /** @type {HTMLElement} */ (trigger.target).tagName === 'A'
-    ) {
-      return;
-    }
-    this.router.transitionTo('variables.variable', variable.path);
-  }
 
   @action goToNewVariable() {
     this.router.transitionTo('variables.new');


### PR DESCRIPTION
Hi @ChefAustin — I was trying to figure out why your changes didn't seem to have the desired effect on the variables page, and I realized it's because of my old long-dormant and unused code for `goToVariable()`!

I've moved the same logic into `handleFileClick()` and `handleFolderClick()` in the variable-paths component, which we use from a few places in the UI. My apologies for leaving this in a difficult to update state in the first place!